### PR TITLE
Change npm package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Retrieves the argument names of a function
 ## Install
 
 ```
-npm install get-parameter-names
+npm install @captemulation/get-parameter-names
 ```
 
 ## Usage
@@ -17,7 +17,7 @@ function foo(bar, baz) {
   return bar + baz
 }
 
-var get = require('get-parameter-names')
+var get = require('@captemulation/get-parameter-names')
 get(foo) // = ['bar', 'baz']
 ```
 
@@ -26,7 +26,7 @@ Also supports fat arrow and default functions
 ```js
 const foo = (a, b = 20) => a + b
 
-var get = require('get-parameter-names')
+var get = require('@captemulation/get-parameter-names')
 get(foo) // = ['a', 'b']
 ```
 


### PR DESCRIPTION
Thanks for creating this fork! Works well on cases where the original package fails.

If you're planning to merge back into `get-parameter-names`, it's probably best to ignore this PR. But seeing that it's a major rewrite I'm guessing this will be maintained separately.